### PR TITLE
Added support for position independent code

### DIFF
--- a/curl.cabal
+++ b/curl.cabal
@@ -34,6 +34,7 @@ library
                    Network.Curl.Debug
 
   c-sources:        curlc.c
+  cc-options:       -fPCI
   Extra-libraries:  curl
   Extensions:       CPP, ForeignFunctionInterface
   Ghc-options:      -Wall


### PR DESCRIPTION
It's weird that the static object needed this, but on my x86_64 machine I ran into some problems. You can find the error logs I had at https://gist.github.com/athanclark/53faae19d44a9de0aceb. I just had to recompile the package in the sandbox and retest the linking.
