### PR TITLE
mask asynchronous exceptions to prevent memory leaks

### DIFF
--- a/Network/Curl/Opts.hs
+++ b/Network/Curl/Opts.hs
@@ -283,7 +283,7 @@ type ProgressFunction
  -> IO CInt --  not sure; 0 is a good one.
 
 type DebugFunction
-  = Curl       --  connection handle
+  = CurlH      --  connection handle
  -> DebugInfo  --  type of call
  -> Ptr CChar  --  data buffer
  -> CInt       --  length of buffer

--- a/curl.cabal
+++ b/curl.cabal
@@ -1,5 +1,5 @@
 name:               curl
-version:            1.3.8.1
+version:            1.3.8.2
 synopsis:           Haskell binding to libcurl
 description:
     libcurl is a client-side URL transfer library, supporting FTP, FTPS, HTTP,

--- a/curl.cabal
+++ b/curl.cabal
@@ -1,5 +1,5 @@
 name:               curl
-version:            1.3.8
+version:            1.3.8.1
 synopsis:           Haskell binding to libcurl
 description:
     libcurl is a client-side URL transfer library, supporting FTP, FTPS, HTTP,

--- a/curl.cabal
+++ b/curl.cabal
@@ -1,5 +1,5 @@
 name:               curl
-version:            1.3.8.2
+version:            1.3.8.3
 synopsis:           Haskell binding to libcurl
 description:
     libcurl is a client-side URL transfer library, supporting FTP, FTPS, HTTP,
@@ -19,10 +19,6 @@ build-type:         Configure
 cabal-version:      >= 1.6
 extra-source-files: configure, configure.ac, curl.buildinfo.in, CHANGES
 
-flag new-base
-  Description: Build with new smaller base library
-  Default: False
-
 library
   Exposed-modules: Network.Curl
                    Network.Curl.Code
@@ -39,12 +35,8 @@ library
   Ghc-options:      -Wall
 
   Build-Depends: base
-  if flag(new-base)
-    Build-depends: base >= 3 && < 5, containers
-  else
-    Build-depends: base < 3
-
-  build-depends: bytestring >= 0.9
+               , containers
+               , bytestring >= 0.9
 
 source-repository head
   type:     git


### PR DESCRIPTION
these functions allocate resources and make them subject to
garbage collection later. if asynchronous exception arrives
in between, memory will be leaked.
