### PR TITLE
Added option to support HTTP/2

### DIFF
--- a/Network/Curl/Opts.hs
+++ b/Network/Curl/Opts.hs
@@ -190,6 +190,7 @@ data HttpVersion
  = HttpVersionNone
  | HttpVersion10
  | HttpVersion11
+ | HttpVersion20
    deriving ( Enum,Show )
 
 data TimeCond


### PR DESCRIPTION
Just one line....Code like the following now works:

    main= curlGet 
        "https://api.httptwo.com/get-protocol/"
        [   
            (CurlHttpVersion HttpVersion20), 
            (CurlURL "https://api.httptwo.com/get-protocol/"),
            (CurlHttpHeaders ["origin:www.httptwo.com"])
        ]