### PR TITLE
Make the new-base flag default to True

### DIFF
--- a/curl.cabal
+++ b/curl.cabal
@@ -21,7 +21,7 @@ extra-source-files: configure, configure.ac, curl.buildinfo.in, CHANGES
 
 flag new-base
   Description: Build with new smaller base library
-  Default: False
+  Default: True
 
 library
   Exposed-modules: Network.Curl


### PR DESCRIPTION
When building `curl` with `--allow-newer=base` (which is often the case when I'm testing packages with GHC HEAD), the `new-base` flag has a tendency to be set to `False`, resulting in build failures (see https://github.com/haskell/cabal/issues/3457#issuecomment-221487085 for further discussion). A simple workaround is to make `new-base` default to `True`, which avoids the issue.