### PR TITLE
Miscellaneous fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *~
-dist
+dist/
+dist-newstyle/
 Network/Curl/*_stub.*
 config.log
 config.status

--- a/Network/Curl.hs
+++ b/Network/Curl.hs
@@ -275,7 +275,7 @@ curlGetResponse url opts = curlGetResponse_ url opts
 -- 'CurlWriteFunction' and 'CurlHeaderFunction' options.
 perform_with_response :: (CurlHeader hdrTy, CurlBuffer bufTy)
                       => Curl
-		      -> IO (CurlResponse_ hdrTy bufTy)
+                      -> IO (CurlResponse_ hdrTy bufTy)
 perform_with_response h = perform_with_response_ h
 
 {-# DEPRECATED perform_with_response "Consider switching to perform_with_response_" #-}
@@ -288,7 +288,7 @@ perform_with_response h = perform_with_response_ h
 -- both headers and body via the 'CurlResponse_' type.
 perform_with_response_ :: (CurlHeader headerTy, CurlBuffer bodyTy)
                        => Curl
-		       -> IO (CurlResponse_ headerTy bodyTy)
+                       -> IO (CurlResponse_ headerTy bodyTy)
 perform_with_response_ h = do
    (finalHeader, gatherHeader) <- newIncomingHeader
    (finalBody,   gatherBody)   <- newIncoming
@@ -324,9 +324,9 @@ do_curl h url opts = do_curl_ h url opts
 
 do_curl_ :: (CurlHeader headerTy, CurlBuffer bodyTy)
          => Curl
-	 -> URLString
-	 -> [CurlOption]
-	 -> IO (CurlResponse_ headerTy bodyTy)
+         -> URLString
+         -> [CurlOption]
+         -> IO (CurlResponse_ headerTy bodyTy)
 do_curl_ h url opts = do
    setDefaultSSLOpts h url
    setopts h opts
@@ -352,8 +352,8 @@ curlHead url opts = initialize >>= \ h ->
 -- Returns the status line and the key-value pairs for the headers.
 curlHead_ :: (CurlHeader headers)
           => URLString
-	  -> [CurlOption]
-	  -> IO (String, headers)
+          -> [CurlOption]
+          -> IO (String, headers)
 curlHead_ url opts = initialize >>= \ h -> do
   (finalHeader, gatherHeader) <- newIncomingHeader
 --  setopt h (CurlVerbose True)

--- a/Network/Curl.hs
+++ b/Network/Curl.hs
@@ -11,7 +11,7 @@
 -- Stability : provisional
 -- Portability: portable
 --
--- A Haskell binding the libcurl library <http://curl.haxx.se/>, a
+-- A Haskell binding the libcurl library <http://curl.se/>, a
 -- proven and feature-rich library for interacting with HTTP(S)\/FTP
 -- servers.
 --

--- a/Network/Curl.hs
+++ b/Network/Curl.hs
@@ -11,15 +11,20 @@
 -- Stability : provisional
 -- Portability: portable
 --
--- A Haskell binding the libcurl library <http://curl.se/>, a
+-- A Haskell binding the @libcurl@ library <http://curl.se/>, a
 -- proven and feature-rich library for interacting with HTTP(S)\/FTP
 -- servers.
 --
--- The binding was initially made against version 7.16.2; libcurl does
+-- The binding was initially made against version 7.16.2; @libcurl@ does
 -- appear to be considerate in not introducing breaking changes wrt
 -- older versions. So, unless you're after the latest features (i.e.,
 -- constructors towards the end the Option type), there's a very good
--- chance your code will work against older installations of libcurl.
+-- chance your code will work against older installations of @libcurl@.
+--
+-- __Warning:__ Any POSIX executable using this package needs to be
+-- linked with the threaded runtime. @libcurl@ is incompatible with
+-- the non-threaded runtime due to the latter's [use of OS signals to
+-- implement timers](https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/rts/signals).
 --
 --------------------------------------------------------------------
 
@@ -153,7 +158,7 @@ instance CurlBuffer LazyBS.ByteString where
     let readFinal = readIORef ref >>= return . LazyBS.fromChunks . reverse
     return (readFinal, \ v -> packCStringLen v >>= \ x -> modifyIORef ref (x:))
 
--- | Should be used once to wrap all uses of libcurl.
+-- | Should be used once to wrap all uses of @libcurl@.
 -- WARNING: the argument should not return before it
 -- is completely done with curl (e.g., no forking or lazy returns)
 withCurlDo :: IO a -> IO a

--- a/Network/Curl/Easy.hs
+++ b/Network/Curl/Easy.hs
@@ -9,10 +9,16 @@
 -- Stability : provisional
 -- Portability: portable
 --
--- Haskell binding to the libcurl <http://curl.se/> \"easy\" API.
+-- Haskell binding to the @libcurl@ <http://curl.se/> \"easy\" API.
 -- The \"easy\" API provides a higher-level, easy-to-get-started calling
 -- interface to the library's wide range of features for interacting
 -- with HTTP\/FTP\/etc servers.
+--
+--
+-- __Warning:__ Any POSIX executable using this package needs to be
+-- linked with the threaded runtime. @libcurl@ is incompatible with
+-- the non-threaded runtime due to the latter's [use of OS signals to
+-- implement timers](https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/rts/signals).
 --
 --------------------------------------------------------------------
 module Network.Curl.Easy

--- a/Network/Curl/Easy.hs
+++ b/Network/Curl/Easy.hs
@@ -24,9 +24,9 @@ module Network.Curl.Easy
 
         , curl_global_init    -- :: CInt -> IO CurlCode
         , curl_global_cleanup -- :: IO ()
-	
-	, curl_version_number -- :: IO Int
-	, curl_version_string -- :: IO String
+
+        , curl_version_number -- :: IO Int
+        , curl_version_string -- :: IO String
         ) where
 
 import Network.Curl.Types

--- a/Network/Curl/Easy.hs
+++ b/Network/Curl/Easy.hs
@@ -9,7 +9,7 @@
 -- Stability : provisional
 -- Portability: portable
 --
--- Haskell binding to the libcurl <http://curl.haxx.se/> \"easy\" API.
+-- Haskell binding to the libcurl <http://curl.se/> \"easy\" API.
 -- The \"easy\" API provides a higher-level, easy-to-get-started calling
 -- interface to the library's wide range of features for interacting
 -- with HTTP\/FTP\/etc servers.

--- a/Network/Curl/Opts.hs
+++ b/Network/Curl/Opts.hs
@@ -254,24 +254,24 @@ toSSHAuthMask (x:xs) =
 
 type WriteFunction
   = Ptr CChar  --  pointer to external buffer holding data
- -> CInt       --  width (in bytes) of each item
- -> CInt       --  number of items
+ -> CSize      --  width (in bytes) of each item
+ -> CSize      --  number of items
  -> Ptr ()     --  state argument (file pointer etc.)
- -> IO CInt    --  number of bytes written.
+ -> IO CSize   --  number of bytes written.
 
 type ReadFunction
   = Ptr CChar  --  pointer to external buffer to fill in.
- -> CInt       --  width (in bytes) of each item
- -> CInt       --  number of items
+ -> CSize      --  width (in bytes) of each item
+ -> CSize      --  number of items
  -> Ptr ()     --  state argument (file pointer etc.)
- -> IO (Maybe CInt) --  how many bytes was copied into buffer; Nothing => abort.
+ -> IO (Maybe CSize) --  how many bytes was copied into buffer; Nothing => abort.
  
 type ReadFunctionPrim
   = Ptr CChar
- -> CInt
- -> CInt
+ -> CSize
+ -> CSize
  -> Ptr ()
- -> IO CInt
+ -> IO CSize
  
 
 type ProgressFunction
@@ -286,7 +286,7 @@ type DebugFunction
   = Curl       --  connection handle
  -> DebugInfo  --  type of call
  -> Ptr CChar  --  data buffer
- -> CInt       --  length of buffer
+ -> CSize      --  length of buffer
  -> Ptr ()     --  state argument
  -> IO ()      --  always 0
 
@@ -304,7 +304,7 @@ type DebugFunctionPrim
   = CurlH      --  connection handle
  -> CInt       --  type of call
  -> Ptr CChar  --  data buffer
- -> CInt       --  length of buffer
+ -> CSize      --  length of buffer
  -> Ptr ()     --  state argument
  -> IO CInt    --  always 0
 
@@ -316,7 +316,7 @@ type SSLCtxtFunction
  -> Ptr ()  --  state argument
  -> IO CInt
 
-curl_readfunc_abort :: CInt
+curl_readfunc_abort :: CSize
 curl_readfunc_abort = 0x10000000
 
 baseLong :: Int

--- a/curl.cabal
+++ b/curl.cabal
@@ -48,5 +48,5 @@ library
 
 source-repository head
   type:     git
-  location: git://github.com/galoisinc/curl.git
+  location: https://github.com/GaloisInc/curl.git
 

--- a/curl.cabal
+++ b/curl.cabal
@@ -1,3 +1,4 @@
+cabal-version:      >= 1.8
 name:               curl
 version:            1.3.8
 synopsis:           Haskell binding to libcurl
@@ -16,7 +17,6 @@ license-file:       LICENSE
 author:             Sigbjorn Finne
 maintainer:         Don Stewart <dons00@gmail.com>
 build-type:         Configure
-cabal-version:      >= 1.6
 extra-source-files: configure, configure.ac, curl.buildinfo.in, CHANGES
 
 flag new-base


### PR DESCRIPTION
This includes fixes to documentation, the cabal file, and the datatypes used in callback functions.

The most important change is adding a warning about needing to use the threaded runtime. It took me quite a few hours of debugging to find out why `libcurl` was returning a highly misleading error (`CurlBadFunctionArgument`) due to being interrupted by a `SIGVTALRM` from the non-threaded runtime.